### PR TITLE
Add headphone image editor tool

### DIFF
--- a/tools/headphone-image-editor/.env.example
+++ b/tools/headphone-image-editor/.env.example
@@ -1,0 +1,10 @@
+# Pluggable search engine. Currently supported: brave
+SEARCH_ENGINE=brave
+
+# Brave Search API key. Get one at https://api.search.brave.com/
+BRAVE_API_KEY=
+
+# Optional overrides
+PORT=5174
+PICTURES_DIR=../../datas/pictures
+HEADPHONES_JSON=./data/headphones.json

--- a/tools/headphone-image-editor/.gitignore
+++ b/tools/headphone-image-editor/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+data/headphones.json
+.env
+.env.local
+*.log

--- a/tools/headphone-image-editor/index.html
+++ b/tools/headphone-image-editor/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Headphone image editor</title>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tools/headphone-image-editor/package.json
+++ b/tools/headphone-image-editor/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "headphone-image-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Local app to refresh headphone product photos in datas/pictures/.",
+  "scripts": {
+    "sync": "python3 scripts/dump_headphones.py",
+    "dev:server": "tsx watch server/index.ts",
+    "dev:client": "vite",
+    "dev": "node scripts/dev.mjs",
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p server/tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@huggingface/transformers": "^3.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/tools/headphone-image-editor/scripts/dev.mjs
+++ b/tools/headphone-image-editor/scripts/dev.mjs
@@ -1,0 +1,20 @@
+import { spawn } from 'node:child_process';
+
+const procs = [
+  spawn('npx', ['tsx', 'watch', 'server/index.ts'], { stdio: 'inherit' }),
+  spawn('npx', ['vite'], { stdio: 'inherit' }),
+];
+
+const shutdown = (code = 0) => {
+  for (const p of procs) {
+    if (!p.killed) p.kill('SIGTERM');
+  }
+  process.exit(code);
+};
+
+for (const p of procs) {
+  p.on('exit', (code) => shutdown(code ?? 0));
+}
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));

--- a/tools/headphone-image-editor/scripts/dump_headphones.py
+++ b/tools/headphone-image-editor/scripts/dump_headphones.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Dump the headphone database to JSON for the TypeScript editor app.
+
+Reads ``datas.headphones.headphones_info`` and writes a flat list to
+``data/headphones.json`` next to this script (resolved relative to the app
+root, ``tools/headphone-image-editor``).
+
+Each entry is::
+
+    {
+      "key": "ABYSS Headphones AB-1266 Phi TC",
+      "brand": "ABYSS Headphones",
+      "model": "AB-1266 Phi TC",
+      "shape": "over-ear",
+      "price": "4995.00",          # optional
+      "picture": "ABYSS Headphones AB-1266 Phi TC.jpg"  # filename if found, else null
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+APP_ROOT = HERE.parent
+REPO_ROOT = APP_ROOT.parent.parent
+
+# Make `import datas` resolve to <repo>/datas without requiring the user to
+# install the package.
+sys.path.insert(0, str(REPO_ROOT))
+
+from datas.headphones import headphones_info  # noqa: E402  (after sys.path tweak)
+
+
+PICTURES_DIR = REPO_ROOT / "datas" / "pictures"
+OUT_PATH = APP_ROOT / "data" / "headphones.json"
+
+
+def find_picture(key: str) -> str | None:
+    for ext in (".png", ".jpg", ".jpeg", ".webp"):
+        candidate = PICTURES_DIR / f"{key}{ext}"
+        if candidate.is_file():
+            return candidate.name
+    return None
+
+
+def main() -> int:
+    entries = []
+    for key, hp in headphones_info.items():
+        if hp.get("skip"):
+            continue
+        entry = {
+            "key": key,
+            "brand": hp.get("brand", ""),
+            "model": hp.get("model", ""),
+            "shape": hp.get("shape", ""),
+            "picture": find_picture(key),
+        }
+        if "price" in hp:
+            entry["price"] = hp["price"]
+        entries.append(entry)
+
+    entries.sort(key=lambda e: (e["brand"].lower(), e["model"].lower()))
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    with_picture = sum(1 for e in entries if e["picture"])
+    print(
+        f"Wrote {len(entries)} headphones to {OUT_PATH.relative_to(APP_ROOT)} "
+        f"({with_picture} with picture, {len(entries) - with_picture} missing)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/headphone-image-editor/server/headphones.ts
+++ b/tools/headphone-image-editor/server/headphones.ts
@@ -1,0 +1,32 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export interface HeadphoneEntry {
+  key: string;
+  brand: string;
+  model: string;
+  shape: string;
+  price?: string;
+  picture: string | null;
+}
+
+export async function loadHeadphones(jsonPath: string): Promise<HeadphoneEntry[]> {
+  const abs = resolve(jsonPath);
+  let text: string;
+  try {
+    text = await readFile(abs, 'utf-8');
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') {
+      throw new Error(
+        `Headphone data not found at ${abs}. Run \`npm run sync\` (or python3 scripts/dump_headphones.py) first.`,
+      );
+    }
+    throw err;
+  }
+  const parsed = JSON.parse(text) as HeadphoneEntry[];
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${abs} is not a JSON array`);
+  }
+  return parsed;
+}

--- a/tools/headphone-image-editor/server/index.ts
+++ b/tools/headphone-image-editor/server/index.ts
@@ -1,0 +1,259 @@
+import { createReadStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadHeadphones } from './headphones.ts';
+import {
+  contentTypeFor,
+  findExistingPicture,
+  safeKey,
+  savePicture,
+  UnsafeKeyError,
+} from './pictures.ts';
+import { getEngine } from './search/registry.ts';
+import { SearchEngineError } from './search/types.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(__dirname, '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+
+const PORT = Number(process.env.PORT ?? 5174);
+const PICTURES_DIR = resolve(
+  APP_ROOT,
+  process.env.PICTURES_DIR ?? '../../datas/pictures',
+);
+const HEADPHONES_JSON = resolve(
+  APP_ROOT,
+  process.env.HEADPHONES_JSON ?? './data/headphones.json',
+);
+
+await loadEnvFile();
+
+type Handler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+) => Promise<void> | void;
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    const handler = route(req.method ?? 'GET', url.pathname);
+    if (!handler) {
+      send(res, 404, { error: 'Not found' });
+      return;
+    }
+    await handler(req, res, url);
+  } catch (err) {
+    handleError(res, err);
+  }
+});
+
+function route(method: string, pathname: string): Handler | null {
+  if (method === 'GET' && pathname === '/api/headphones') return handleList;
+  if (method === 'GET' && pathname.startsWith('/api/picture/')) return handlePicture;
+  if (method === 'GET' && pathname === '/api/search') return handleSearch;
+  if (method === 'GET' && pathname === '/api/proxy') return handleProxy;
+  if (method === 'POST' && pathname === '/api/save') return handleSave;
+  if (method === 'GET' && pathname === '/api/health') return (_req, res) => send(res, 200, { ok: true });
+  return null;
+}
+
+const handleList: Handler = async (_req, res) => {
+  const entries = await loadHeadphones(HEADPHONES_JSON);
+  send(res, 200, entries);
+};
+
+const handlePicture: Handler = async (_req, res, url) => {
+  const key = decodeURIComponent(url.pathname.slice('/api/picture/'.length));
+  safeKey(key);
+  const found = await findExistingPicture(PICTURES_DIR, key);
+  if (!found) {
+    send(res, 404, { error: 'No picture for this key' });
+    return;
+  }
+  res.writeHead(200, {
+    'Content-Type': contentTypeFor(found.ext),
+    'Cache-Control': 'no-store',
+  });
+  createReadStream(found.path).pipe(res);
+};
+
+const handleSearch: Handler = async (_req, res, url) => {
+  const q = url.searchParams.get('q')?.trim();
+  const count = Number(url.searchParams.get('count') ?? '10');
+  if (!q) {
+    send(res, 400, { error: 'Missing q' });
+    return;
+  }
+  const engine = getEngine();
+  const hits = await engine.search(q, Number.isFinite(count) ? count : 10);
+  send(res, 200, { engine: engine.name, hits });
+};
+
+const handleProxy: Handler = async (_req, res, url) => {
+  const target = url.searchParams.get('url');
+  if (!target) {
+    send(res, 400, { error: 'Missing url' });
+    return;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    send(res, 400, { error: 'Invalid url' });
+    return;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    send(res, 400, { error: 'Only http(s) urls allowed' });
+    return;
+  }
+  const upstream = await fetch(parsed, {
+    headers: { 'User-Agent': 'spinorama-headphone-image-editor/0.1' },
+    redirect: 'follow',
+  });
+  if (!upstream.ok || !upstream.body) {
+    send(res, 502, { error: `Upstream returned ${upstream.status}` });
+    return;
+  }
+  const ctype = upstream.headers.get('content-type') ?? 'application/octet-stream';
+  if (!ctype.startsWith('image/')) {
+    send(res, 415, { error: `Refusing non-image content-type ${ctype}` });
+    return;
+  }
+  res.writeHead(200, {
+    'Content-Type': ctype,
+    'Cache-Control': 'no-store',
+  });
+  const { Readable } = await import('node:stream');
+  Readable.fromWeb(upstream.body).pipe(res);
+};
+
+interface SaveBody {
+  key?: unknown;
+  pngBase64?: unknown;
+  confirm?: unknown;
+}
+
+const handleSave: Handler = async (req, res) => {
+  const body = await readJson<SaveBody>(req);
+  if (body.confirm !== true) {
+    send(res, 400, { error: 'Missing confirm: true' });
+    return;
+  }
+  if (typeof body.key !== 'string' || typeof body.pngBase64 !== 'string') {
+    send(res, 400, { error: 'key and pngBase64 (string) are required' });
+    return;
+  }
+  const key = safeKey(body.key);
+  const cleaned = body.pngBase64.replace(/^data:image\/png;base64,/, '');
+  const bytes = Buffer.from(cleaned, 'base64');
+  if (bytes.length === 0) {
+    send(res, 400, { error: 'Empty image payload' });
+    return;
+  }
+  // Sanity check PNG magic.
+  const magic = bytes.subarray(0, 8);
+  const expected = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (!magic.equals(expected)) {
+    send(res, 400, { error: 'Not a PNG (bad magic)' });
+    return;
+  }
+  const result = await savePicture(PICTURES_DIR, key, bytes);
+  send(res, 200, {
+    written: result.writtenPath,
+    removed: result.removed,
+    bytes: bytes.length,
+  });
+};
+
+function send(res: ServerResponse, status: number, body: unknown): void {
+  const payload = Buffer.from(JSON.stringify(body));
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': payload.length,
+  });
+  res.end(payload);
+}
+
+async function readJson<T>(req: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const max = 32 * 1024 * 1024; // 32 MB cap
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    total += buf.length;
+    if (total > max) throw new HttpError(413, 'Payload too large');
+    chunks.push(buf);
+  }
+  const text = Buffer.concat(chunks).toString('utf-8');
+  if (!text) return {} as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new HttpError(400, 'Invalid JSON');
+  }
+}
+
+class HttpError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function handleError(res: ServerResponse, err: unknown): void {
+  if (err instanceof UnsafeKeyError) {
+    send(res, 400, { error: err.message });
+    return;
+  }
+  if (err instanceof HttpError) {
+    send(res, err.status, { error: err.message });
+    return;
+  }
+  if (err instanceof SearchEngineError) {
+    send(res, err.status, { error: err.message });
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[server] unhandled', err);
+  send(res, 500, { error: message });
+}
+
+async function loadEnvFile(): Promise<void> {
+  const envPath = resolve(APP_ROOT, '.env');
+  try {
+    const text = await readFile(envPath, 'utf-8');
+    for (const rawLine of text.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const eq = line.indexOf('=');
+      if (eq < 0) continue;
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== 'ENOENT') throw err;
+  }
+}
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[server] http://127.0.0.1:${PORT}`);
+  console.log(`[server] pictures dir: ${PICTURES_DIR}`);
+  console.log(`[server] headphones json: ${HEADPHONES_JSON}`);
+  console.log(`[server] repo root: ${REPO_ROOT}`);
+});

--- a/tools/headphone-image-editor/server/index.ts
+++ b/tools/headphone-image-editor/server/index.ts
@@ -1,6 +1,8 @@
+import { lookup } from 'node:dns/promises';
 import { createReadStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { isIP } from 'node:net';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -93,6 +95,9 @@ const handleSearch: Handler = async (_req, res, url) => {
   send(res, 200, { engine: engine.name, hits });
 };
 
+const PROXY_TIMEOUT_MS = 10_000;
+const PROXY_MAX_BYTES = 10 * 1024 * 1024;
+
 const handleProxy: Handler = async (_req, res, url) => {
   const target = url.searchParams.get('url');
   if (!target) {
@@ -110,10 +115,29 @@ const handleProxy: Handler = async (_req, res, url) => {
     send(res, 400, { error: 'Only http(s) urls allowed' });
     return;
   }
-  const upstream = await fetch(parsed, {
-    headers: { 'User-Agent': 'spinorama-headphone-image-editor/0.1' },
-    redirect: 'follow',
-  });
+  if (!(await isPublicHost(parsed.hostname))) {
+    send(res, 400, { error: 'Refusing to fetch from non-public host' });
+    return;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
+  let upstream: Response;
+  try {
+    upstream = await fetch(parsed, {
+      headers: { 'User-Agent': 'spinorama-headphone-image-editor/0.1' },
+      // Manual redirects: we re-validate before following anything else.
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (upstream.status >= 300 && upstream.status < 400) {
+    send(res, 502, { error: 'Upstream redirect not followed' });
+    return;
+  }
   if (!upstream.ok || !upstream.body) {
     send(res, 502, { error: `Upstream returned ${upstream.status}` });
     return;
@@ -123,13 +147,66 @@ const handleProxy: Handler = async (_req, res, url) => {
     send(res, 415, { error: `Refusing non-image content-type ${ctype}` });
     return;
   }
+  const declared = Number(upstream.headers.get('content-length') ?? '0');
+  if (declared > PROXY_MAX_BYTES) {
+    send(res, 413, { error: 'Upstream image exceeds size cap' });
+    return;
+  }
+
   res.writeHead(200, {
     'Content-Type': ctype,
     'Cache-Control': 'no-store',
   });
-  const { Readable } = await import('node:stream');
-  Readable.fromWeb(upstream.body).pipe(res);
+
+  let received = 0;
+  for await (const chunk of upstream.body as unknown as AsyncIterable<Uint8Array>) {
+    received += chunk.byteLength;
+    if (received > PROXY_MAX_BYTES) {
+      res.destroy(new Error('Upstream image exceeded size cap'));
+      return;
+    }
+    if (!res.write(chunk)) {
+      await new Promise<void>((r) => res.once('drain', () => r()));
+    }
+  }
+  res.end();
 };
+
+async function isPublicHost(host: string): Promise<boolean> {
+  if (!host) return false;
+  if (isIP(host)) return !isPrivateAddress(host);
+  try {
+    const addrs = await lookup(host, { all: true, verbatim: true });
+    if (addrs.length === 0) return false;
+    return addrs.every((a) => !isPrivateAddress(a.address));
+  } catch {
+    return false;
+  }
+}
+
+function isPrivateAddress(addr: string): boolean {
+  const a = addr.toLowerCase();
+  // IPv6
+  if (a === '::' || a === '::1') return true;
+  if (a.startsWith('fe80:') || a.startsWith('fec0:')) return true; // link/site-local
+  if (/^f[cd][0-9a-f]{2}:/.test(a)) return true; // unique local
+  if (/^ff[0-9a-f]{2}:/.test(a)) return true; // multicast
+  const v4mapped = /^::ffff:([0-9.]+)$/.exec(a);
+  if (v4mapped) return isPrivateAddress(v4mapped[1]);
+  // IPv4
+  const m = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(a);
+  if (!m) return false;
+  const [o1, o2] = [Number(m[1]), Number(m[2])];
+  if (o1 === 0) return true; // 0.0.0.0/8
+  if (o1 === 10) return true;
+  if (o1 === 127) return true;
+  if (o1 === 169 && o2 === 254) return true; // link-local
+  if (o1 === 172 && o2 >= 16 && o2 <= 31) return true;
+  if (o1 === 192 && o2 === 168) return true;
+  if (o1 === 100 && o2 >= 64 && o2 <= 127) return true; // CGNAT
+  if (o1 >= 224) return true; // multicast + reserved + broadcast
+  return false;
+}
 
 interface SaveBody {
   key?: unknown;
@@ -219,9 +296,9 @@ function handleError(res: ServerResponse, err: unknown): void {
     send(res, err.status, { error: err.message });
     return;
   }
-  const message = err instanceof Error ? err.message : String(err);
+  // Do not leak raw error / stack details to the client.
   console.error('[server] unhandled', err);
-  send(res, 500, { error: message });
+  send(res, 500, { error: 'Internal server error' });
 }
 
 async function loadEnvFile(): Promise<void> {

--- a/tools/headphone-image-editor/server/pictures.ts
+++ b/tools/headphone-image-editor/server/pictures.ts
@@ -1,0 +1,82 @@
+import { stat, unlink, writeFile } from 'node:fs/promises';
+import { resolve, sep, normalize, join } from 'node:path';
+
+const KNOWN_EXTS = ['.png', '.jpg', '.jpeg', '.webp'] as const;
+
+export class UnsafeKeyError extends Error {
+  constructor(key: string) {
+    super(`Unsafe headphone key: ${key}`);
+    this.name = 'UnsafeKeyError';
+  }
+}
+
+export function safeKey(key: string): string {
+  if (!key) throw new UnsafeKeyError(key);
+  if (key.includes('\0')) throw new UnsafeKeyError(key);
+  if (key.includes('/') || key.includes('\\')) throw new UnsafeKeyError(key);
+  if (key === '.' || key === '..' || key.includes('..')) throw new UnsafeKeyError(key);
+  if (key !== normalize(key)) throw new UnsafeKeyError(key);
+  return key;
+}
+
+export function picturePathFor(picturesDir: string, key: string, ext: string): string {
+  const safe = safeKey(key);
+  const root = resolve(picturesDir);
+  const candidate = resolve(join(root, `${safe}${ext}`));
+  if (!candidate.startsWith(root + sep) && candidate !== root) {
+    throw new UnsafeKeyError(key);
+  }
+  return candidate;
+}
+
+export async function findExistingPicture(
+  picturesDir: string,
+  key: string,
+): Promise<{ path: string; ext: string } | null> {
+  for (const ext of KNOWN_EXTS) {
+    const path = picturePathFor(picturesDir, key, ext);
+    try {
+      const s = await stat(path);
+      if (s.isFile()) return { path, ext };
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+export async function savePicture(
+  picturesDir: string,
+  key: string,
+  pngBytes: Buffer,
+): Promise<{ writtenPath: string; removed: string[] }> {
+  const target = picturePathFor(picturesDir, key, '.png');
+  await writeFile(target, pngBytes);
+
+  const removed: string[] = [];
+  for (const ext of KNOWN_EXTS) {
+    if (ext === '.png') continue;
+    const path = picturePathFor(picturesDir, key, ext);
+    try {
+      await unlink(path);
+      removed.push(path);
+    } catch {
+      /* not present */
+    }
+  }
+  return { writtenPath: target, removed };
+}
+
+export function contentTypeFor(ext: string): string {
+  switch (ext.toLowerCase()) {
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    default:
+      return 'application/octet-stream';
+  }
+}

--- a/tools/headphone-image-editor/server/search/brave.ts
+++ b/tools/headphone-image-editor/server/search/brave.ts
@@ -1,0 +1,74 @@
+import { type ImageHit, type SearchEngine, SearchEngineError } from './types.ts';
+
+interface BraveImageResult {
+  title?: string;
+  url?: string;
+  source?: string;
+  thumbnail?: { src?: string };
+  properties?: { url?: string };
+  image?: { url?: string; width?: number; height?: number };
+}
+
+interface BraveImageResponse {
+  results?: BraveImageResult[];
+  message?: string;
+}
+
+const ENDPOINT = 'https://api.search.brave.com/res/v1/images/search';
+
+export class BraveSearchEngine implements SearchEngine {
+  readonly name = 'brave';
+
+  constructor(private readonly apiKey: string) {
+    if (!apiKey) {
+      throw new Error('BRAVE_API_KEY is required for the brave search engine');
+    }
+  }
+
+  async search(query: string, count: number): Promise<ImageHit[]> {
+    const params = new URLSearchParams({
+      q: query,
+      count: String(Math.min(Math.max(count, 1), 50)),
+      safesearch: 'strict',
+      country: 'us',
+    });
+    const url = `${ENDPOINT}?${params.toString()}`;
+    const res = await fetch(url, {
+      headers: {
+        'X-Subscription-Token': this.apiKey,
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip',
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new SearchEngineError(
+        `Brave Search returned ${res.status}: ${body.slice(0, 200)}`,
+        res.status === 401 || res.status === 403 ? 502 : 502,
+      );
+    }
+
+    const data = (await res.json()) as BraveImageResponse;
+    const results = data.results ?? [];
+    return results
+      .map(toHit)
+      .filter((hit): hit is ImageHit => hit !== null)
+      .slice(0, count);
+  }
+}
+
+function toHit(r: BraveImageResult): ImageHit | null {
+  const imageUrl = r.properties?.url ?? r.image?.url;
+  const thumbnailUrl = r.thumbnail?.src ?? imageUrl;
+  const sourceUrl = r.url ?? r.source ?? '';
+  if (!imageUrl || !thumbnailUrl) return null;
+  return {
+    title: r.title ?? '',
+    thumbnailUrl,
+    imageUrl,
+    sourceUrl,
+    width: r.image?.width,
+    height: r.image?.height,
+  };
+}

--- a/tools/headphone-image-editor/server/search/registry.ts
+++ b/tools/headphone-image-editor/server/search/registry.ts
@@ -1,0 +1,16 @@
+import { BraveSearchEngine } from './brave.ts';
+import type { SearchEngine } from './types.ts';
+
+let cached: SearchEngine | null = null;
+
+export function getEngine(): SearchEngine {
+  if (cached) return cached;
+  const name = (process.env.SEARCH_ENGINE ?? 'brave').toLowerCase();
+  switch (name) {
+    case 'brave':
+      cached = new BraveSearchEngine(process.env.BRAVE_API_KEY ?? '');
+      return cached;
+    default:
+      throw new Error(`Unknown SEARCH_ENGINE: ${name}`);
+  }
+}

--- a/tools/headphone-image-editor/server/search/types.ts
+++ b/tools/headphone-image-editor/server/search/types.ts
@@ -1,0 +1,23 @@
+export interface ImageHit {
+  title: string;
+  thumbnailUrl: string;
+  imageUrl: string;
+  sourceUrl: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SearchEngine {
+  readonly name: string;
+  search(query: string, count: number): Promise<ImageHit[]>;
+}
+
+export class SearchEngineError extends Error {
+  constructor(
+    message: string,
+    public readonly status = 502,
+  ) {
+    super(message);
+    this.name = 'SearchEngineError';
+  }
+}

--- a/tools/headphone-image-editor/server/tsconfig.json
+++ b/tools/headphone-image-editor/server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tools/headphone-image-editor/src/api.ts
+++ b/tools/headphone-image-editor/src/api.ts
@@ -1,0 +1,71 @@
+export interface HeadphoneEntry {
+  key: string;
+  brand: string;
+  model: string;
+  shape: string;
+  price?: string;
+  picture: string | null;
+}
+
+export interface ImageHit {
+  title: string;
+  thumbnailUrl: string;
+  imageUrl: string;
+  sourceUrl: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SearchResponse {
+  engine: string;
+  hits: ImageHit[];
+}
+
+export interface SaveResponse {
+  written: string;
+  removed: string[];
+  bytes: number;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}: ${body}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function listHeadphones(): Promise<HeadphoneEntry[]> {
+  return getJson<HeadphoneEntry[]>('/api/headphones');
+}
+
+export function pictureUrl(key: string): string {
+  return `/api/picture/${encodeURIComponent(key)}`;
+}
+
+export function search(query: string, count = 10): Promise<SearchResponse> {
+  const params = new URLSearchParams({ q: query, count: String(count) });
+  return getJson<SearchResponse>(`/api/search?${params.toString()}`);
+}
+
+export function proxiedImageUrl(imageUrl: string): string {
+  return `/api/proxy?url=${encodeURIComponent(imageUrl)}`;
+}
+
+export function savePicture(key: string, pngBase64: string): Promise<SaveResponse> {
+  return postJson<SaveResponse>('/api/save', { key, pngBase64, confirm: true });
+}

--- a/tools/headphone-image-editor/src/bgremove.ts
+++ b/tools/headphone-image-editor/src/bgremove.ts
@@ -1,0 +1,87 @@
+// Background removal via transformers.js + RMBG-1.4 (local model, runs in-browser).
+// Lazy-loaded so opening the app's grid does not pull in ~50 MB of weights.
+
+import {
+  AutoModel,
+  AutoProcessor,
+  RawImage,
+  env,
+  type PreTrainedModel,
+  type Processor,
+} from '@huggingface/transformers';
+
+env.allowLocalModels = false;
+
+const MODEL_ID = 'briaai/RMBG-1.4';
+
+interface Pipeline {
+  model: PreTrainedModel;
+  processor: Processor;
+}
+
+let pipelinePromise: Promise<Pipeline> | null = null;
+
+export function loadPipeline(onProgress?: (msg: string) => void): Promise<Pipeline> {
+  if (pipelinePromise) return pipelinePromise;
+  onProgress?.('Loading background removal model (~44 MB, cached after first load)…');
+  pipelinePromise = (async () => {
+    const model = await AutoModel.from_pretrained(MODEL_ID, {
+      config: { model_type: 'custom' } as never,
+    });
+    const processor = await AutoProcessor.from_pretrained(MODEL_ID, {
+      config: {
+        do_normalize: true,
+        do_pad: false,
+        do_rescale: true,
+        do_resize: true,
+        image_mean: [0.5, 0.5, 0.5],
+        feature_extractor_type: 'ImageFeatureExtractor',
+        image_std: [1, 1, 1],
+        resample: 2,
+        rescale_factor: 0.00392156862745098,
+        size: { width: 1024, height: 1024 },
+      },
+    } as never);
+    onProgress?.('Model ready.');
+    return { model, processor };
+  })();
+  return pipelinePromise;
+}
+
+/**
+ * Take an RGBA ImageData and return a new ImageData with the alpha channel
+ * replaced by the foreground mask predicted by RMBG-1.4. Pixels outside the
+ * subject become transparent.
+ */
+export async function removeBackground(
+  source: ImageData,
+  onProgress?: (msg: string) => void,
+): Promise<ImageData> {
+  const { model, processor } = await loadPipeline(onProgress);
+
+  const rawImage = new RawImage(
+    new Uint8ClampedArray(source.data),
+    source.width,
+    source.height,
+    4,
+  );
+
+  onProgress?.('Running segmentation…');
+  const callable = processor as unknown as (img: RawImage) => Promise<{ pixel_values: unknown }>;
+  const { pixel_values } = await callable(rawImage);
+  const inferenceOutput = (await model({ input: pixel_values })) as {
+    output: { mul(scalar: number): unknown }[];
+  };
+
+  const maskTensorRaw = await RawImage.fromTensor(
+    inferenceOutput.output[0].mul(255) as never,
+  );
+  const mask = await maskTensorRaw.resize(source.width, source.height);
+
+  const out = new Uint8ClampedArray(source.data);
+  for (let i = 0; i < mask.data.length; i++) {
+    out[i * 4 + 3] = mask.data[i];
+  }
+  onProgress?.('Background removed.');
+  return new ImageData(out, source.width, source.height);
+}

--- a/tools/headphone-image-editor/src/editor.ts
+++ b/tools/headphone-image-editor/src/editor.ts
@@ -1,0 +1,243 @@
+import { proxiedImageUrl, savePicture, type ImageHit } from './api.ts';
+import { removeBackground } from './bgremove.ts';
+
+const OUTPUT_SIZE = 800;
+
+export interface EditorOptions {
+  key: string;
+  hit: ImageHit;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface State {
+  source: HTMLImageElement;
+  /** Mask-applied RGBA pixels (only set after bg removal). */
+  cleaned: ImageData | null;
+  /** Logical scale: 1 = fit-contain at default. */
+  scale: number;
+  /** Center offset within the 800×800 canvas, in pixels. */
+  offsetX: number;
+  offsetY: number;
+  bgRemoved: boolean;
+}
+
+export async function openEditor(opts: EditorOptions): Promise<void> {
+  const root = renderShell(opts);
+  document.body.append(root);
+
+  const status = root.querySelector<HTMLElement>('[data-role=status]')!;
+  const canvas = root.querySelector<HTMLCanvasElement>('[data-role=canvas]')!;
+  const scaleInput = root.querySelector<HTMLInputElement>('[data-role=scale]')!;
+  const bgToggle = root.querySelector<HTMLInputElement>('[data-role=bg-toggle]')!;
+  const saveBtn = root.querySelector<HTMLButtonElement>('[data-role=save]')!;
+  const closeBtn = root.querySelector<HTMLButtonElement>('[data-role=close]')!;
+
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+  canvas.width = OUTPUT_SIZE;
+  canvas.height = OUTPUT_SIZE;
+
+  closeBtn.addEventListener('click', () => {
+    root.remove();
+    opts.onClose();
+  });
+
+  status.textContent = 'Downloading image…';
+  const img = await loadImage(proxiedImageUrl(opts.hit.imageUrl));
+
+  const state: State = {
+    source: img,
+    cleaned: null,
+    scale: 1,
+    offsetX: 0,
+    offsetY: 0,
+    bgRemoved: false,
+  };
+
+  setupPan(canvas, state, () => render(ctx, state));
+  scaleInput.addEventListener('input', () => {
+    state.scale = Number(scaleInput.value);
+    render(ctx, state);
+  });
+
+  bgToggle.addEventListener('change', async () => {
+    if (!bgToggle.checked) {
+      state.bgRemoved = false;
+      render(ctx, state);
+      return;
+    }
+    if (!state.cleaned) {
+      bgToggle.disabled = true;
+      try {
+        state.cleaned = await runBackgroundRemoval(img, (msg) => (status.textContent = msg));
+      } catch (err) {
+        status.textContent = `Background removal failed: ${(err as Error).message}`;
+        bgToggle.checked = false;
+        bgToggle.disabled = false;
+        return;
+      }
+      bgToggle.disabled = false;
+    }
+    state.bgRemoved = true;
+    status.textContent = 'Background removed.';
+    render(ctx, state);
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    saveBtn.disabled = true;
+    status.textContent = 'Saving…';
+    try {
+      const dataUrl = canvas.toDataURL('image/png');
+      const result = await savePicture(opts.key, dataUrl);
+      status.textContent = `Saved (${(result.bytes / 1024).toFixed(1)} kB).`;
+      opts.onSaved();
+      setTimeout(() => {
+        root.remove();
+        opts.onClose();
+      }, 600);
+    } catch (err) {
+      status.textContent = `Save failed: ${(err as Error).message}`;
+      saveBtn.disabled = false;
+    }
+  });
+
+  status.textContent = 'Adjust framing, then save.';
+  render(ctx, state);
+}
+
+function renderShell(opts: EditorOptions): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'modal';
+  wrap.innerHTML = `
+    <div class="editor">
+      <header>
+        <strong>${escapeHtml(opts.key)}</strong>
+        <button data-role="close" type="button">Cancel</button>
+      </header>
+      <div class="editor-body">
+        <canvas data-role="canvas"></canvas>
+        <aside class="editor-controls">
+          <label>
+            <span>Scale</span>
+            <input data-role="scale" type="range" min="0.2" max="2.5" step="0.01" value="1">
+          </label>
+          <label class="row">
+            <input data-role="bg-toggle" type="checkbox">
+            <span>Remove background</span>
+          </label>
+          <p class="hint">Drag the canvas to recenter the headphone. Output is PNG 800×800, transparent, fit-contain.</p>
+          <button data-role="save" class="primary" type="button">Save &amp; replace</button>
+          <p data-role="status" class="status"></p>
+        </aside>
+      </div>
+    </div>
+  `;
+  return wrap;
+}
+
+function setupPan(canvas: HTMLCanvasElement, state: State, redraw: () => void): void {
+  let dragging = false;
+  let startX = 0;
+  let startY = 0;
+  let baseX = 0;
+  let baseY = 0;
+  canvas.addEventListener('pointerdown', (e) => {
+    dragging = true;
+    canvas.setPointerCapture(e.pointerId);
+    startX = e.clientX;
+    startY = e.clientY;
+    baseX = state.offsetX;
+    baseY = state.offsetY;
+  });
+  canvas.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    const rect = canvas.getBoundingClientRect();
+    const px2logical = OUTPUT_SIZE / rect.width;
+    state.offsetX = baseX + (e.clientX - startX) * px2logical;
+    state.offsetY = baseY + (e.clientY - startY) * px2logical;
+    redraw();
+  });
+  canvas.addEventListener('pointerup', () => {
+    dragging = false;
+  });
+  canvas.addEventListener('pointercancel', () => {
+    dragging = false;
+  });
+}
+
+function render(ctx: CanvasRenderingContext2D, state: State): void {
+  ctx.clearRect(0, 0, OUTPUT_SIZE, OUTPUT_SIZE);
+  // Light checkerboard background so transparency is visible.
+  drawCheckerboard(ctx, OUTPUT_SIZE, OUTPUT_SIZE, 16);
+
+  const sw = state.source.naturalWidth;
+  const sh = state.source.naturalHeight;
+  if (!sw || !sh) return;
+
+  const fit = Math.min(OUTPUT_SIZE / sw, OUTPUT_SIZE / sh);
+  const drawW = sw * fit * state.scale;
+  const drawH = sh * fit * state.scale;
+  const cx = OUTPUT_SIZE / 2 + state.offsetX;
+  const cy = OUTPUT_SIZE / 2 + state.offsetY;
+  const dx = cx - drawW / 2;
+  const dy = cy - drawH / 2;
+
+  if (state.bgRemoved && state.cleaned) {
+    const off = document.createElement('canvas');
+    off.width = state.cleaned.width;
+    off.height = state.cleaned.height;
+    off.getContext('2d')!.putImageData(state.cleaned, 0, 0);
+    ctx.drawImage(off, dx, dy, drawW, drawH);
+  } else {
+    ctx.drawImage(state.source, dx, dy, drawW, drawH);
+  }
+}
+
+function drawCheckerboard(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  cell: number,
+): void {
+  for (let y = 0; y < h; y += cell) {
+    for (let x = 0; x < w; x += cell) {
+      const dark = (((x / cell) | 0) + ((y / cell) | 0)) % 2 === 0;
+      ctx.fillStyle = dark ? '#e9eef3' : '#f7f9fc';
+      ctx.fillRect(x, y, cell, cell);
+    }
+  }
+}
+
+async function runBackgroundRemoval(
+  img: HTMLImageElement,
+  onStatus: (s: string) => void,
+): Promise<ImageData> {
+  const w = img.naturalWidth;
+  const h = img.naturalHeight;
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  const cctx = c.getContext('2d', { willReadFrequently: true })!;
+  cctx.drawImage(img, 0, 0);
+  const src = cctx.getImageData(0, 0, w, h);
+  return removeBackground(src, onStatus);
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load ${src}`));
+    img.src = src;
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/tools/headphone-image-editor/src/grid.ts
+++ b/tools/headphone-image-editor/src/grid.ts
@@ -1,0 +1,100 @@
+import { listHeadphones, pictureUrl, type HeadphoneEntry } from './api.ts';
+import { openEditor } from './editor.ts';
+import { openPicker } from './picker.ts';
+
+export async function mountGrid(root: HTMLElement): Promise<void> {
+  root.innerHTML = `
+    <div class="toolbar">
+      <input data-role="search" type="search" placeholder="Filter brand or model…" autofocus>
+      <span data-role="count" class="muted"></span>
+    </div>
+    <div data-role="grid" class="grid"></div>
+  `;
+
+  const searchInput = root.querySelector<HTMLInputElement>('[data-role=search]')!;
+  const grid = root.querySelector<HTMLElement>('[data-role=grid]')!;
+  const count = root.querySelector<HTMLElement>('[data-role=count]')!;
+
+  let entries: HeadphoneEntry[] = [];
+  try {
+    entries = await listHeadphones();
+  } catch (err) {
+    grid.innerHTML = `<p class="status error">Failed to load headphones: ${escapeHtml(
+      (err as Error).message,
+    )}</p>`;
+    return;
+  }
+
+  const render = (filter: string): void => {
+    const f = filter.trim().toLowerCase();
+    const filtered = f
+      ? entries.filter((e) => `${e.brand} ${e.model}`.toLowerCase().includes(f))
+      : entries;
+    count.textContent = `${filtered.length} / ${entries.length}`;
+    grid.replaceChildren(...filtered.map(renderCard));
+  };
+
+  searchInput.addEventListener('input', () => render(searchInput.value));
+  render('');
+
+  function renderCard(entry: HeadphoneEntry): HTMLElement {
+    const card = document.createElement('article');
+    card.className = 'card';
+    card.dataset.key = entry.key;
+    const imgSrc = entry.picture ? pictureUrl(entry.key) : '';
+    const imgHtml = imgSrc
+      ? `<img loading="lazy" alt="" src="${escapeAttr(imgSrc)}">`
+      : '<div class="placeholder">no picture</div>';
+    card.innerHTML = `
+      <div class="card-img">${imgHtml}</div>
+      <div class="card-meta">
+        <strong>${escapeHtml(entry.brand)}</strong>
+        <span>${escapeHtml(entry.model)}</span>
+        <span class="muted">${escapeHtml(entry.shape)}${
+          entry.price ? ` · $${escapeHtml(entry.price)}` : ''
+        }</span>
+      </div>
+    `;
+    card.addEventListener('click', () => onPick(entry, card));
+    return card;
+  }
+
+  function onPick(entry: HeadphoneEntry, card: HTMLElement): void {
+    openPicker({
+      query: `${entry.brand} ${entry.model} headphone product photo`,
+      onClose: () => {},
+      onPick: (hit) => {
+        document.querySelectorAll('.modal').forEach((m) => m.remove());
+        openEditor({
+          key: entry.key,
+          hit,
+          onClose: () => {},
+          onSaved: () => {
+            const img = card.querySelector('img');
+            const fresh = `${pictureUrl(entry.key)}?t=${Date.now()}`;
+            if (img) {
+              img.src = fresh;
+            } else {
+              card.querySelector('.card-img')!.innerHTML =
+                `<img loading="lazy" alt="" src="${escapeAttr(fresh)}">`;
+            }
+            entry.picture = `${entry.key}.png`;
+          },
+        });
+      },
+    });
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}

--- a/tools/headphone-image-editor/src/main.ts
+++ b/tools/headphone-image-editor/src/main.ts
@@ -1,0 +1,11 @@
+import './styles.css';
+import { mountGrid } from './grid.ts';
+
+const root = document.querySelector<HTMLElement>('#app');
+if (!root) {
+  throw new Error('#app not found');
+}
+mountGrid(root).catch((err) => {
+  console.error(err);
+  root.innerHTML = `<p class="status error">${(err as Error).message}</p>`;
+});

--- a/tools/headphone-image-editor/src/picker.ts
+++ b/tools/headphone-image-editor/src/picker.ts
@@ -1,0 +1,77 @@
+import { search, type ImageHit } from './api.ts';
+
+export interface PickerOptions {
+  query: string;
+  onPick: (hit: ImageHit) => void;
+  onClose: () => void;
+}
+
+export async function openPicker(opts: PickerOptions): Promise<void> {
+  const root = document.createElement('div');
+  root.className = 'modal';
+  root.innerHTML = `
+    <div class="picker">
+      <header>
+        <strong>Pick a replacement image</strong>
+        <span class="muted">${escapeHtml(opts.query)}</span>
+        <button data-role="close" type="button">Close</button>
+      </header>
+      <div class="picker-grid" data-role="grid">
+        <p class="status">Searching…</p>
+      </div>
+    </div>
+  `;
+  document.body.append(root);
+
+  root.querySelector<HTMLButtonElement>('[data-role=close]')!.addEventListener('click', () => {
+    root.remove();
+    opts.onClose();
+  });
+
+  const grid = root.querySelector<HTMLElement>('[data-role=grid]')!;
+
+  try {
+    const { hits, engine } = await search(opts.query, 10);
+    if (hits.length === 0) {
+      grid.innerHTML = '<p class="status">No images found.</p>';
+      return;
+    }
+    grid.innerHTML = '';
+    grid.dataset.engine = engine;
+    for (const hit of hits) {
+      grid.append(renderHit(hit, () => opts.onPick(hit)));
+    }
+  } catch (err) {
+    grid.innerHTML = `<p class="status error">${escapeHtml((err as Error).message)}</p>`;
+  }
+}
+
+function renderHit(hit: ImageHit, onPick: () => void): HTMLElement {
+  const card = document.createElement('button');
+  card.type = 'button';
+  card.className = 'hit';
+  const dims =
+    hit.width && hit.height ? `<span class="muted">${hit.width}×${hit.height}</span>` : '';
+  card.innerHTML = `
+    <img loading="lazy" alt="" src="${escapeAttr(hit.thumbnailUrl)}">
+    <div class="hit-meta">
+      <span class="hit-title">${escapeHtml(hit.title || hit.sourceUrl)}</span>
+      ${dims}
+    </div>
+  `;
+  card.addEventListener('click', onPick);
+  return card;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}

--- a/tools/headphone-image-editor/src/styles.css
+++ b/tools/headphone-image-editor/src/styles.css
@@ -1,0 +1,293 @@
+:root {
+  --bg: #0f1216;
+  --panel: #161a20;
+  --panel-2: #1d232b;
+  --border: #2a313b;
+  --fg: #e6eaf0;
+  --muted: #8a93a0;
+  --accent: #4f8cff;
+  --accent-fg: #fff;
+  --error: #ff6b6b;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.toolbar input[type='search'] {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 1rem;
+}
+
+.toolbar input[type='search']:focus {
+  outline: 2px solid var(--accent);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  padding-top: 1rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    transform 0.08s ease,
+    border-color 0.08s ease;
+}
+
+.card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.card-img {
+  aspect-ratio: 1 / 1;
+  background: var(--panel-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.placeholder {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.card-meta strong {
+  font-weight: 600;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.picker,
+.editor {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  width: min(1100px, 100%);
+  max-height: 95vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.picker > header,
+.editor > header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.picker > header strong,
+.editor > header strong {
+  flex: 1;
+  font-weight: 600;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+button {
+  padding: 0.45rem 0.85rem;
+  background: var(--panel-2);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+button.primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+
+.picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.hit {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.hit:hover {
+  border-color: var(--accent);
+}
+
+.hit img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  background: var(--panel);
+  border-radius: 4px;
+}
+
+.hit-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hit-title {
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.editor-body {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+@media (max-width: 800px) {
+  .editor-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.editor canvas {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 1 / 1;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  touch-action: none;
+  cursor: grab;
+}
+
+.editor canvas:active {
+  cursor: grabbing;
+}
+
+.editor-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.editor-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.editor-controls label.row {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.editor-controls .hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.status.error {
+  color: var(--error);
+}

--- a/tools/headphone-image-editor/tsconfig.json
+++ b/tools/headphone-image-editor/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/tools/headphone-image-editor/vite.config.ts
+++ b/tools/headphone-image-editor/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:5174',
+        changeOrigin: false,
+      },
+    },
+  },
+  build: {
+    target: 'es2022',
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
## Summary

A small local TypeScript app under `tools/headphone-image-editor/` that helps populate the headphone product photos in `datas/pictures/`.

For every headphone in `datas.headphones.headphones_info`, the app shows a card (current picture or "no picture" placeholder). Clicking a card runs a web image search and shows 10 candidates. Picking a candidate downloads it through a server-side proxy, then on the client:

- Optional background removal via **transformers.js** running locally (`briaai/RMBG-1.4`, WebGPU with WASM fallback — no external API, no key for this step).
- Manual scale slider + drag-to-pan recentering.
- Composite onto a transparent **800×800 PNG, fit-contain**.

Save overwrites `datas/pictures/<Brand> <Model>.png` and removes any prior `.jpg`/`.jpeg`/`.webp` for that key.

### Search is pluggable

`server/search/types.ts` defines a tiny `SearchEngine` interface; `server/search/registry.ts` selects an implementation from `SEARCH_ENGINE` env var (`brave` is the only one shipped). Adding another engine is a single new file under `server/search/` plus a registry entry.

### Minimum-libraries goal

- **Backend**: zero runtime deps, Node's built-in `http` + `fetch` + `node:stream`.
- **Frontend**: plain DOM/CSS bundled by Vite. Sole runtime dep: `@huggingface/transformers` (required for local bg removal).
- Dev-only: `tsx`, `typescript`, `vite`, `@types/node`.

### Layout

```
tools/headphone-image-editor/
  scripts/
    dump_headphones.py     # imports datas.headphones, emits data/headphones.json
    dev.mjs                # spawns tsx server + vite, no concurrently dep
  server/
    index.ts               # /api/headphones, /api/picture/:key, /api/search, /api/proxy, /api/save
    headphones.ts pictures.ts
    search/{types,brave,registry}.ts
  src/
    main.ts grid.ts picker.ts editor.ts bgremove.ts api.ts styles.css
  index.html  vite.config.ts  tsconfig.json  server/tsconfig.json
  .env.example  .gitignore
```

### Safety

- Headphone keys are sanitized server-side (no `..`, slashes, NUL); resolved path must stay inside `PICTURES_DIR`.
- API key only on the server; never sent to the browser.
- Save endpoint requires `confirm: true`; payload must start with PNG magic bytes; 32 MB cap.
- Image proxy refuses non-`image/*` content types and only allows `http(s)` URLs.
- `data/headphones.json` and `.env` are gitignored.

## Test plan

- [ ] `cp .env.example .env` and set `BRAVE_API_KEY`.
- [ ] `npm install`.
- [ ] `npm run sync` — confirms `data/headphones.json` is generated (155 headphones today).
- [ ] `npm run typecheck` — passes for both `tsconfig.json` (frontend) and `server/tsconfig.json` (server).
- [ ] `npx vite build` — produces `dist/` without errors.
- [ ] `npm run dev` — server on :5174, vite on :5173. Health check `curl :5174/api/health` → `{"ok":true}`.
- [ ] Open `http://localhost:5173`, see the grid populated with 155 cards.
- [ ] Filter input narrows the grid live.
- [ ] Click a card → 10 search candidates render within ~2 s.
- [ ] Pick one → editor preview shows on a checkerboard background.
- [ ] Toggle "Remove background" → first time downloads ~44 MB model, then mask is applied; alpha shows through the checkerboard.
- [ ] Drag canvas to recenter; scale slider zooms.
- [ ] Save → `datas/pictures/<Brand> <Model>.png` exists; any prior `.jpg`/`.jpeg`/`.webp` for the same key is removed.
- [ ] Negative: `curl ":5174/api/picture/..%2Fetc%2Fpasswd"` → 400.
- [ ] Negative: `curl -X POST :5174/api/save -d '{"key":"x","pngBase64":"a"}'` → 400 "Missing confirm: true".

https://claude.ai/code/session_01EgHoYTLuMW3g9U14n2MHCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgHoYTLuMW3g9U14n2MHCB)_